### PR TITLE
 While building, lerna uses yarn instead of npm #85  (issue #85)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "version": "0.8.5",
   "useWorkspaces": true,
-  "npmClient": "yarn"
+  "npmClient": "npm"
 }


### PR DESCRIPTION
When running, Lerna uses "yarn", which runs "yarn run dev ", which results in ERROR: [Errno 2] No such file or directory: 'run' . This can be easily fixed by changing yarn to npm in lerna.json's npmClient.