### PR TITLE
Feature: Allow transactions to supply their own fee

### DIFF
--- a/packages/extension/src/languages/en.json
+++ b/packages/extension/src/languages/en.json
@@ -208,6 +208,8 @@
   "sign.info.fee": "Fee",
   "sign.info.memo": "Memo",
   "sign.info.warning.empty-memo": "(Empty memo)",
+  "sign.info.warning.supplied-fee": "<b>IMPORTANT</b> - This transaction already has a fee set:",
+  "sign.info.fee.override": "Click here if you want to override the supplied fee.",
   "sign.info.gas": "Gas",
   "sign.button.approve": "Approve",
   "sign.button.reject": "Reject",

--- a/packages/extension/src/pages/sign/details-tab.tsx
+++ b/packages/extension/src/pages/sign/details-tab.tsx
@@ -4,6 +4,7 @@ import { observer } from "mobx-react-lite";
 import { useStore } from "../../stores";
 
 import styleDetailsTab from "./details-tab.module.scss";
+import style from "./style.module.scss";
 
 import { renderAminoMessage } from "./amino";
 import { Msg } from "@cosmjs/launchpad";
@@ -16,7 +17,7 @@ import {
   SignDocHelper,
 } from "@keplr-wallet/hooks";
 import { useLanguage } from "../../languages";
-import { Badge, Label } from "reactstrap";
+import { Badge, Label, Button } from "reactstrap";
 import { renderDirectMessage } from "./direct";
 
 export const DetailsTab: FunctionComponent<{
@@ -26,8 +27,16 @@ export const DetailsTab: FunctionComponent<{
   gasConfig: IGasConfig;
 
   disableInputs: boolean | undefined;
+  disableFeeInputs: boolean;
 }> = observer(
-  ({ signDocHelper, memoConfig, feeConfig, gasConfig, disableInputs }) => {
+  ({
+    signDocHelper,
+    memoConfig,
+    feeConfig,
+    gasConfig,
+    disableInputs,
+    disableFeeInputs,
+  }) => {
     const { chainStore, priceStore, accountStore } = useStore();
     const intl = useIntl();
 
@@ -41,7 +50,7 @@ export const DetailsTab: FunctionComponent<{
         ? signDocHelper.signDocWrapper.aminoSignDoc.msgs
         : signDocHelper.signDocWrapper.protoSignDoc.txMsgs
       : [];
-
+    let _disableFeeInputs = disableFeeInputs;
     const renderedMsgs = (() => {
       if (mode === "amino") {
         return (msgs as readonly Msg[]).map((msg, i) => {
@@ -116,7 +125,7 @@ export const DetailsTab: FunctionComponent<{
             </div>
           </React.Fragment>
         )}
-        {!disableInputs ? (
+        {!disableInputs && !_disableFeeInputs ? (
           <FeeButtons
             feeConfig={feeConfig}
             gasConfig={gasConfig}
@@ -143,6 +152,19 @@ export const DetailsTab: FunctionComponent<{
                     {priceStore
                       .calculatePrice(language.fiatCurrency, feeConfig.fee)
                       ?.toString()}
+
+                    <Button
+                      className={style.button}
+                      color="primary"
+                      onClick={async (e) => {
+                        e.preventDefault();
+                        _disableFeeInputs = false;
+                      }}
+                    >
+                      {intl.formatMessage({
+                        id: "sign.button.approve",
+                      })}
+                    </Button>
                   </div>
                 ) : null}
               </div>

--- a/packages/extension/src/pages/sign/details-tab.tsx
+++ b/packages/extension/src/pages/sign/details-tab.tsx
@@ -34,9 +34,6 @@ export const DetailsTab: FunctionComponent<{
       useManualFee(feeConfig.isManual);
     }, [feeConfig.isManual]);
     const intl = useIntl();
-    console.log(feeConfig.isManual);
-    console.log(feeConfig);
-    console.log("Disable fee:" + manualFee);
     const language = useLanguage();
 
     const mode = signDocHelper.signDocWrapper

--- a/packages/extension/src/pages/sign/index.tsx
+++ b/packages/extension/src/pages/sign/index.tsx
@@ -91,7 +91,7 @@ export const SignPage: FunctionComponent = observer(() => {
       signDocHelper.setSignDocWrapper(data.data.signDocWrapper);
       gasConfig.setGas(data.data.signDocWrapper.gas);
       memoConfig.setMemo(data.data.signDocWrapper.memo);
-      if (isSignDocInternalSend) {
+      if (isSignDocInternalSend || data.data.signDocWrapper.fees[0]) {
         feeConfig.setManualFee(data.data.signDocWrapper.fees[0]);
       }
       setSigner(data.data.signer);
@@ -112,7 +112,7 @@ export const SignPage: FunctionComponent = observer(() => {
   ] = useState(false);
 
   const disableInputs = isSignDocInternalSend || isLoadingSignDocInternalSend;
-
+  const disableFeeInputs = feeConfig.isManual;
   return (
     <HeaderLayout
       showChainName
@@ -168,6 +168,7 @@ export const SignPage: FunctionComponent = observer(() => {
               feeConfig={feeConfig}
               gasConfig={gasConfig}
               disableInputs={disableInputs}
+              disableFeeInputs={disableFeeInputs}
             />
           ) : null}
         </div>

--- a/packages/extension/src/pages/sign/index.tsx
+++ b/packages/extension/src/pages/sign/index.tsx
@@ -112,7 +112,7 @@ export const SignPage: FunctionComponent = observer(() => {
   ] = useState(false);
 
   const disableInputs = isSignDocInternalSend || isLoadingSignDocInternalSend;
-  const disableFeeInputs = feeConfig.isManual;
+
   return (
     <HeaderLayout
       showChainName
@@ -168,7 +168,6 @@ export const SignPage: FunctionComponent = observer(() => {
               feeConfig={feeConfig}
               gasConfig={gasConfig}
               disableInputs={disableInputs}
-              disableFeeInputs={disableFeeInputs}
             />
           ) : null}
         </div>

--- a/packages/hooks/src/sign-doc/index.ts
+++ b/packages/hooks/src/sign-doc/index.ts
@@ -44,8 +44,12 @@ export class SignDocHelper {
           denom: fee.denom,
         };
       }),
-      granter: protoSignDoc.authInfo.fee?.granter,
-      payer: protoSignDoc.authInfo.fee?.payer,
+      granter: protoSignDoc.authInfo.fee?.granter
+        ? protoSignDoc.authInfo.fee?.granter
+        : null,
+      payer: protoSignDoc.authInfo.fee?.payer
+        ? protoSignDoc.authInfo.fee?.granter
+        : null,
     });
 
     const newSignDoc = cosmos.tx.v1beta1.SignDoc.create({

--- a/packages/hooks/src/tx/fee.ts
+++ b/packages/hooks/src/tx/fee.ts
@@ -62,7 +62,9 @@ export class FeeConfig extends TxChainSetter implements IFeeConfig {
   setFeeType(feeType: FeeType | undefined) {
     this._feeType = feeType;
     this._manualFee = undefined;
-    this._isManual = true;
+    if (feeType) {
+      this._isManual = false;
+    }
   }
 
   get isManual(): boolean {
@@ -76,6 +78,7 @@ export class FeeConfig extends TxChainSetter implements IFeeConfig {
   setManualFee(fee: CoinPrimitive) {
     this._manualFee = fee;
     this._feeType = undefined;
+    this._isManual = true;
   }
 
   get feeCurrencies(): Currency[] {

--- a/packages/hooks/src/tx/fee.ts
+++ b/packages/hooks/src/tx/fee.ts
@@ -29,6 +29,9 @@ export class FeeConfig extends TxChainSetter implements IFeeConfig {
   @observable
   protected _manualFee: CoinPrimitive | undefined = undefined;
 
+  @observable
+  protected _isManual: boolean = false;
+
   constructor(
     chainGetter: ChainGetter,
     initialChainId: string,
@@ -59,8 +62,12 @@ export class FeeConfig extends TxChainSetter implements IFeeConfig {
   setFeeType(feeType: FeeType | undefined) {
     this._feeType = feeType;
     this._manualFee = undefined;
+    this._isManual = true;
   }
 
+  get isManual(): boolean {
+    return this._isManual;
+  }
   get feeType(): FeeType | undefined {
     return this._feeType;
   }

--- a/packages/hooks/src/tx/types.ts
+++ b/packages/hooks/src/tx/types.ts
@@ -31,7 +31,7 @@ export interface IFeeConfig extends ITxChainSetter {
   fee: CoinPretty | undefined;
   getFeeTypePretty(feeType: FeeType): CoinPretty;
   getFeePrimitive(): CoinPrimitive | undefined;
-
+  isManual: boolean;
   getError(): Error | undefined;
 }
 


### PR DESCRIPTION
This PR handles the case where a transaction to be signed using the Keplr-supplied offline signer has a fee already set.

The supplied fee is displayed to the user in the signing screen with a warning that it was set by the calling application already and an option to switch to the Keplr fee selection buttons to override it.

I am unfamiliar with mobx so not sure I have approached the local-state handling of the details tab component the right way.

Please let me know if any adjustements/changes are needed.