### PR TITLE
Update Secret Network chainId to secret-3

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -171,7 +171,7 @@ export const EmbedChainInfos: ChainInfo[] = [
     rpcConfig: SECRET_NETWORK_RPC_CONFIG,
     rest: SECRET_NETWORK_REST_ENDPOINT,
     restConfig: SECRET_NETWORK_REST_CONFIG,
-    chainId: "secret-2",
+    chainId: "secret-3",
     chainName: "Secret Network",
     stakeCurrency: {
       coinDenom: "SCRT",


### PR DESCRIPTION
I'm not 100% sure, but I believe updating this will make it so the block explorer will update from:

https://secretnodes.com/secret/chains/secret-2/accounts...

to the appropriate:

https://secretnodes.com/secret/chains/secret-3/accounts...

As the chainId was increased from 2->3.