### PR TITLE
feature: ethermint/evmos account support

### DIFF
--- a/packages/cosmos/src/account/index.ts
+++ b/packages/cosmos/src/account/index.ts
@@ -59,6 +59,9 @@ export class BaseAccount implements Account {
         baseVestingAccount.BaseAccount ||
         baseVestingAccount.baseAccount ||
         baseVestingAccount.base_account;
+    } else if (value.base_account && value.code_hash) {
+      //  Support for Ethermint chains (Evmos/Crypto.com)
+      value = value.base_account;
     }
 
     let address = value.address;


### PR DESCRIPTION
Closes #196 

Checking the presence of `code_hash` is only needed to avoid possible conflicts in case any other chain uses `base_account` to send data.

`code_hash` is just the hex representation of the account, used for smart contracts on `ethermint`