### PR TITLE
Add beta support for cheqd network

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -27,6 +27,10 @@ import {
   BETA_STRAIGHTEDGE_REST_CONFIG,
   BETA_STRAIGHTEDGE_RPC_ENDPOINT,
   BETA_STRAIGHTEDGE_RPC_CONFIG,
+  BETA_CHEQD_RPC_ENDPOINT,
+  BETA_CHEQD_RPC_CONFIG,
+  BETA_CHEQD_REST_ENDPOINT,
+  BETA_CHEQD_REST_CONFIG,
   AKASH_RPC_ENDPOINT,
   AKASH_RPC_CONFIG,
   AKASH_REST_ENDPOINT,
@@ -75,10 +79,6 @@ import {
   AGORIC_RPC_CONFIG,
   AGORIC_REST_ENDPOINT,
   AGORIC_REST_CONFIG,
-  CHEQD_RPC_ENDPOINT,
-  CHEQD_RPC_CONFIG,
-  CHEQD_REST_ENDPOINT,
-  CHEQD_REST_CONFIG,
 } from "./config.var";
 
 export const EmbedChainInfos: ChainInfo[] = [
@@ -1229,10 +1229,10 @@ export const EmbedChainInfos: ChainInfo[] = [
     beta: true,
   },
   {
-    rpc: CHEQD_REST_ENDPOINT,
-    rpcConfig: CHEQD_RPC_CONFIG,
-    rest: CHEQD_REST_ENDPOINT,
-    restConfig: CHEQD_REST_ENDPOINT,
+    rpc: BETA_CHEQD_REST_ENDPOINT,
+    rpcConfig: BETA_CHEQD_RPC_CONFIG,
+    rest: BETA_CHEQD_REST_ENDPOINT,
+    restConfig: BETA_CHEQD_REST_ENDPOINT,
     chainId: "cheqd-mainnet-1",
     chainName: "cheqd",
     stakeCurrency: {
@@ -1261,6 +1261,7 @@ export const EmbedChainInfos: ChainInfo[] = [
       average: 0.00000005,
       high: 0.0000001,
     },
+    beta: true,
     features: ["stargate"],
   },
 ];

--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -75,6 +75,10 @@ import {
   AGORIC_RPC_CONFIG,
   AGORIC_REST_ENDPOINT,
   AGORIC_REST_CONFIG,
+  CHEQD_RPC_ENDPOINT,
+  CHEQD_RPC_CONFIG,
+  CHEQD_REST_ENDPOINT,
+  CHEQD_REST_CONFIG,
 } from "./config.var";
 
 export const EmbedChainInfos: ChainInfo[] = [
@@ -1223,6 +1227,41 @@ export const EmbedChainInfos: ChainInfo[] = [
       high: 0.04 * Math.pow(10, 12),
     },
     beta: true,
+  },
+  {
+    rpc: CHEQD_REST_ENDPOINT,
+    rpcConfig: CHEQD_RPC_CONFIG,
+    rest: CHEQD_REST_ENDPOINT,
+    restConfig: CHEQD_REST_ENDPOINT,
+    chainId: "cheqd-mainnet-1",
+    chainName: "cheqd",
+    stakeCurrency: {
+      coinDenom: "CHEQD",
+      coinMinimalDenom: "ncheq",
+      coinDecimals: 9,
+    },
+    bip44: { coinType: 118 },
+    bech32Config: Bech32Address.defaultBech32Config("cheqd"),
+    currencies: [
+      {
+        coinDenom: "CHEQ",
+        coinMinimalDenom: "ncheq",
+        coinDecimals: 9,
+      },
+    ],
+    feeCurrencies: [
+      {
+        coinDenom: "CHEQ",
+        coinMinimalDenom: "ncheq",
+        coinDecimals: 9,
+      },
+    ],
+    gasPriceStep: {
+      low: 0.000000025,
+      average: 0.00000005,
+      high: 0.0000001,
+    },
+    features: ["stargate"],
   },
 ];
 


### PR DESCRIPTION
I'd like to request a review to add the cheqd network with beta classification. We'll use the `suggestChain` method for now, but would love for the Chainapsis team to consider us for beta inclusion.

Please let me know any question/concerns.