### PR TITLE
Update default kava fees amounts

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -965,6 +965,11 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinGeckoId: "kava",
       },
     ],
+    gasPriceStep: {
+      low: 0,
+      average: 0.001,
+      high: 0.25,
+    },
     coinType: 459,
   },
   {


### PR DESCRIPTION
Hi, I work at kava-labs. We are working on integrated the Keplr wallet into our webapp and we would like to specify the fee amounts for low, medium, and high within the keplr walllet extension.

It is unclear what the correct process is to get these updated. I've provided both the expected values below and a code change.

Expected Fee Amounts:
- Low: 0 KAVA (no fee)
- Medium: 0.001 KAVA
- High: 0.25 KAVA

@Thunnini @delivan Please let me know if you need anything else for this.